### PR TITLE
Better handling of env vars which include query params

### DIFF
--- a/generate-config.sh
+++ b/generate-config.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -eu
 
-source <(grep -v '^#' "./.env" | sed -E 's|^(.+)=(.*)$|: ${\1=\2}; export \1|g')
+source <(
+    grep -v '^#' "./.env" |
+    sed -E 's|^([^=]+)=(.*)$|export \1="\2"|g'
+)
 
 config_files=(
     "verifiers/btc/database.env"


### PR DESCRIPTION
Current handling of exporting env vars with query params results in:

`NODE_RPC_URL=https://dogecoin-api.flare.network?x-apikey`

New approach properly handles `=` characters that could be present in value.