### PR TITLE
Dynamically adjust start_block_number for XRPL Indexer to Prevent Indexing error due to online_delete

### DIFF
--- a/verifiers/xrp/docker-compose.yaml
+++ b/verifiers/xrp/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       - ./config.toml:/app/config.toml
       - ./init-config.sh:/app/init-config.sh
     environment:
-      - FORCE_UPDATE_START_BLOCK=true
+      - FORCE_UPDATE_START_BLOCK=false
       - DIFFERENCE_BLOCK_FORCE_CHANGE_START_BLOCK=300000
     entrypoint: ["/bin/bash", "/app/init-config.sh"]
     

--- a/verifiers/xrp/docker-compose.yaml
+++ b/verifiers/xrp/docker-compose.yaml
@@ -25,7 +25,12 @@ services:
     restart: unless-stopped
     volumes:
       - ./config.toml:/app/config.toml
-
+      - ./init-config.sh:/app/init-config.sh
+    environment:
+      - FORCE_UPDATE_START_BLOCK=true
+      - DIFFERENCE_BLOCK_FORCE_CHANGE_START_BLOCK=300000
+    entrypoint: ["/bin/bash", "/app/init-config.sh"]
+    
   verifier:
     image: ghcr.io/flare-foundation/verifier-indexer-api:v1.1.0
     container_name: verifier-xrp-verifier

--- a/verifiers/xrp/init-config.sh
+++ b/verifiers/xrp/init-config.sh
@@ -53,8 +53,7 @@ if [[ "$ledger_range" =~ ^([0-9]+)-([0-9]+)$ ]]; then
     fi
 else
     echo "Could not parse complete_ledgers: $ledger_range"
-    echo "Fallback: updating to $cluster_start_block"
-    update_start_block_number
+    echo "Using start_block_number value."
 fi
 
 exec ./xrp-indexer

--- a/verifiers/xrp/init-config.sh
+++ b/verifiers/xrp/init-config.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+command -v jq >/dev/null 2>&1 || apt update && apt install -y jq curl
+
+CONFIG_FILE="/app/config.toml"
+THRESHOLD="${DIFFERENCE_BLOCK_FORCE_CHANGE_START_BLOCK:-300000}"
+
+cluster_start_block=$(curl -s -X POST https://xrplcluster.com/ \
+  -d '{ "method": "server_info", "params": [{}] }' \
+  -H "Content-Type: application/json" | jq '.result.info.validated_ledger.seq - 4')
+
+if ! [[ "$cluster_start_block" =~ ^[0-9]+$ ]]; then
+    echo "Invalid start_block from cluster: $cluster_start_block"
+    exec ./xrp-indexer
+fi
+
+echo "Cluster start block: $cluster_start_block"
+
+rpc_url=$(grep -oP 'url\s*=\s*"\K[^"]+' "$CONFIG_FILE")
+
+if [[ -z "$rpc_url" ]]; then
+    echo "Failed to find blockchain URL in config.toml"
+    exec ./xrp-indexer
+fi
+
+ledger_range=$(curl -s -X POST "$rpc_url" \
+  -d '{ "method": "server_info", "params": [{}] }' \
+  -H "Content-Type: application/json" | jq -r '.result.info.complete_ledgers')
+
+update_start_block_number() {
+  tmp_file=$(mktemp)
+  sed "s/^start_block_number = .*/start_block_number = $cluster_start_block/" "$CONFIG_FILE" > "$tmp_file" \
+    && cat "$tmp_file" > "$CONFIG_FILE" \
+    && rm "$tmp_file"
+}
+
+if [[ "$ledger_range" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+    lower=${BASH_REMATCH[1]}
+    upper=${BASH_REMATCH[2]}
+    range=$((upper - lower))
+
+    echo "Local ledger range: $lower - $upper (range: $range)"
+    echo "Threshold from DIFFERENCE_BLOCK_FORCE_CHANGE_START_BLOCK: $THRESHOLD"
+
+    if [[ "$FORCE_UPDATE_START_BLOCK" == "true" ]]; then
+        echo "FORCE_UPDATE_START_BLOCK is enabled: updating to $cluster_start_block"
+        update_start_block_number
+    elif (( range > THRESHOLD )); then
+        echo "Range exceeds threshold ($THRESHOLD); updating to $cluster_start_block"
+        update_start_block_number
+    else
+        echo "Ledger range is within threshold; no update needed"
+    fi
+else
+    echo "Could not parse complete_ledgers: $ledger_range"
+    echo "Fallback: updating to $cluster_start_block"
+    update_start_block_number
+fi
+
+exec ./xrp-indexer


### PR DESCRIPTION
- Use latest block from xrplcluster.com
- Only override start_block_number by checking the difference of upper and lower local node block by certain threshold. (300000 blocks)
- Allow force override and configurable threshold